### PR TITLE
Revert changelog's distribution from 'oneiric' to 'unstable'

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-xen-api (0.1-6) oneiric; urgency=low
+xen-api (0.1-6) unstable; urgency=low
 
   * Fix the xapissl init script so that it's no longer an init script
 


### PR DESCRIPTION
Keep debian branch at unstable, and keep ubuntu branch at oneiric.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
