### PR TITLE
Update changelog for libxen-ocaml change

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xen-api (0.1-7) unstable; urgency=low
+
+  * Fix control file following renaming of libxen-4.1-ocaml to libxen-ocaml
+
+ -- Mike McClurg <mike.mcclurg@citrix.com>  Tue, 29 Nov 2011 09:34:18 +0000
+
 xen-api (0.1-6) unstable; urgency=low
 
   * Fix the xapissl init script so that it's no longer an init script


### PR DESCRIPTION
I've bumped the changelog from -6 to -7, because of your dependency change wrt libxen-ocaml. I've also bumped the ubuntu branches' changelog; this should be pulled as well.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
