### PR TITLE
Don't start xenvmd in message forwarding logic

### DIFF
--- a/ocaml/xapi/xapi_services.ml
+++ b/ocaml/xapi/xapi_services.ml
@@ -133,8 +133,6 @@ let call_xenvmd_on_srmaster __context req from sr_uuid =
   if Helpers.i_am_srmaster ~__context ~sr
   then begin
     let path = Filename.concat "/var/lib/xenvmd" sr_uuid in
-    if !Xapi_globs.manage_xenvmd then
-      Xapi_xenvmd.start sr_uuid;
     http_proxy_to_unix_sock req from path "xenvmd"
   end else begin
     let sr_master = Helpers.get_srmaster ~__context ~sr in

--- a/ocaml/xapi/xapi_xenvmd.ml
+++ b/ocaml/xapi/xapi_xenvmd.ml
@@ -94,7 +94,6 @@ let assert_config_present sr = assert_file_present (configfile_path sr) NoConfig
    pidfile. Xenvmd will itself lock the pidfile while it is up, so
    xapi's attempt will fail if the process still exists. *)
 let is_running sr =
-  debug "Checking for xenvmd running for sr: %s" sr;
   try
     let l = lockfile_path sr in
     assert_file_present l NoLockFile;
@@ -106,8 +105,8 @@ let is_running sr =
     false
   with
   | NoLockFile -> debug "Caught NoLockFile (xenvmd not running)"; false (* Lockfile missing *)
-  | Unix.Unix_error (Unix.EAGAIN, _, _) -> debug "Caught EAGAIN (xenvmd running)"; true  (* Locked by xenvmd *)
-  | Unix.Unix_error (Unix.EACCES, _, _) -> debug "Caught EACCESS (xenvmd running)"; true  (* Locked by xenvmd *)
+  | Unix.Unix_error (Unix.EAGAIN, _, _)
+  | Unix.Unix_error (Unix.EACCES, _, _) -> true (* Locked by xenvmd *)
   | e -> raise e
 
 (* Verify that xenvmd is running for a particular SR. If xenvmd is not


### PR DESCRIPTION
Instead we will wait for the SM to start it. Starting it on demand (from a xenvm command) can cause issues if the PBD is not plugged.