### PR TITLE
Use PPX-based RPC interface to RRDD

### DIFF
--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -1,6 +1,6 @@
 OCAMLPACKS = oclock xml-light2 cdrom pciutil sexpr xcp stunnel		\
              http-svr netdev tapctl rpclib xenstore-compat	\
-             uuid gzip sha1 sha.sha1 xcp.network xcp.rrd xcp.storage	\
+             uuid gzip sha1 sha.sha1 xcp.network xcp.rrd_ppx xcp.storage	\
              xcp.xen xcp.memory xcp.v6 tar tar.unix oPasswd xcp-inventory \
              rrdd-plugin rrd-transport pci
 

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -15,7 +15,7 @@
  *  @group Main Loop and Start-up
 *)
 
-module Rrdd = Rrd_client.Client
+module Rrdd = Rrd_rpc_client
 
 open Stdext
 open Fun

--- a/ocaml/xapi/monitor_master.ml
+++ b/ocaml/xapi/monitor_master.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Rrdd = Rrd_client.Client
+module Rrdd = Rrd_rpc_client
 
 open Stdext
 open Listext

--- a/ocaml/xapi/monitor_pvs_proxy.ml
+++ b/ocaml/xapi/monitor_pvs_proxy.ml
@@ -20,6 +20,7 @@ open Monitor_dbcalls_cache
 
 module D = Debug.Make(struct let name = "monitor_pvs_proxy" end)
 open D
+module Ds = Rrd_idl.DS
 
 module StringSet = Set.Make(struct type t = string let compare = compare end)
 let dont_log_error = ref StringSet.empty

--- a/ocaml/xapi/rrdd_helper.ml
+++ b/ocaml/xapi/rrdd_helper.ml
@@ -13,15 +13,13 @@
  *)
 
 
-open Data_source
-
-let to_API_data_source (ds : t) = {
-  API.data_source_name_label = ds.name;
-  data_source_name_description = ds.description;
-  data_source_enabled = ds.enabled;
-  data_source_standard = ds.standard;
-  data_source_units = ds.units;
-  data_source_min = ds.min;
-  data_source_max = ds.max;
+let to_API_data_source (ds : Rrd_idl.t) = {
+  API.data_source_name_label = ds.Rrd_idl.name;
+  data_source_name_description = ds.Rrd_idl.description;
+  data_source_enabled = ds.Rrd_idl.enabled;
+  data_source_standard = ds.Rrd_idl.standard;
+  data_source_units = ds.Rrd_idl.units;
+  data_source_min = ds.Rrd_idl.min;
+  data_source_max = ds.Rrd_idl.max;
   data_source_value = 0.;
 }

--- a/ocaml/xapi/xapi_fuse.ml
+++ b/ocaml/xapi/xapi_fuse.ml
@@ -17,7 +17,7 @@
 module D = Debug.Make(struct let name="xapi_fuse" end)
 open D
 
-module Rrdd = Rrd_client.Client
+module Rrdd = Rrd_rpc_client
 
 let time f =
   let start = Unix.gettimeofday () in

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -21,7 +21,7 @@
 module D = Debug.Make(struct let name="xapi_ha" end)
 open D
 
-module Rrdd = Rrd_client.Client
+module Rrdd = Rrd_rpc_client
 
 open Stdext
 open Listext
@@ -322,7 +322,7 @@ module Monitor = struct
                  let statefile = float_of_int (local.Xha_interface.LiveSetInformation.RawStatus.statefile_latency) /. 1000. in
                  let heartbeat_latency = float_of_int local.Xha_interface.LiveSetInformation.RawStatus.heartbeat_latency /. 1000. -. (float_of_int timeouts.Timeouts.heart_beat_interval) in
                  let xapi_latency = float_of_int (local.Xha_interface.LiveSetInformation.RawStatus.xapi_healthcheck_latency) /. 1000. in
-                 let statefile_latencies = List.map (fun vdi -> let open Rrd.Statefile_latency in {id = vdi.Static_vdis.uuid; latency = Some statefile}) statefiles in
+                 let statefile_latencies = List.map (fun vdi -> let open Rrd_idl.Statefile_latency in {id = vdi.Static_vdis.uuid; latency = Some statefile}) statefiles in
                  log_and_ignore_exn (fun () -> Rrdd.HA.enable_and_update ~statefile_latencies ~heartbeat_latency ~xapi_latency)
               ) liveset.Xha_interface.LiveSetInformation.raw_status_on_local_host;
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Rrdd = Rrd_client.Client
+module Rrdd = Rrd_rpc_client
 
 open Stdext
 open Fun
@@ -998,7 +998,7 @@ let sync_data ~__context ~host =
 let backup_rrds ~__context ~host ~delay =
   Xapi_periodic_scheduler.add_to_queue "RRD backup" Xapi_periodic_scheduler.OneShot
     delay (fun _ ->
-        log_and_ignore_exn (Rrdd.backup_rrds ~remote_address:(try Some (Pool_role.get_master_address ()) with _ -> None));
+        log_and_ignore_exn (Rrdd.backup_rrds ?remote_address:(try Some (Pool_role.get_master_address ()) with _ -> None));
         log_and_ignore_exn (fun () ->
             List.iter (fun sr ->
                 Xapi_sr.maybe_copy_sr_rrds ~__context ~sr

--- a/ocaml/xapi/xapi_stats.ml
+++ b/ocaml/xapi/xapi_stats.ml
@@ -14,6 +14,7 @@
 
 open Rrdd_plugin
 module D = Debug.Make(struct let name = "xapi_stats" end)
+module Ds = Rrd_idl.DS
 
 let generate_master_stats ~__context =
   let session_count =
@@ -153,7 +154,7 @@ let start () =
              ~uid:"xapi-stats"
              ~neg_shift:0.5
              ~target:(Reporter.Local shared_page_count)
-             ~protocol:Rrd_interface.V2
+             ~protocol:Rrd_idl.V2
              ~dss_f:(fun () -> generate_stats ~__context ~master)
          in
          reporter_cache := (Some reporter))

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module Rrdd = Rrd_client.Client
+module Rrdd = Rrd_rpc_client
 
 open Stdext
 open Fun

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -21,7 +21,7 @@ open Listext
 module D = Debug.Make(struct let name="xapi" end)
 open D
 
-module Rrdd = Rrd_client.Client
+module Rrdd = Rrd_rpc_client
 
 let assoc_opt key assocs = Opt.of_exception (fun () -> List.assoc key assocs)
 let bool_of_assoc key assocs = match assoc_opt key assocs with

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -24,7 +24,7 @@ open Threadext
 open Pervasiveext
 open Fun
 module XenAPI = Client.Client
-module Rrdd = Rrd_client.Client
+module Rrdd = Rrd_rpc_client
 open Xenops_interface
 open Xapi_xenops_queue
 


### PR DESCRIPTION
This commit changes Xapi to use the new PPX-based RPC interface provided
by the xcp-idl component. The client side is actually part of the
xcp-idl component such that most changes just make sure that it is
called. Otherwise the location of some type definitions have changed in
xcp-idl.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>